### PR TITLE
fix: don't use anaconda defaults channel

### DIFF
--- a/workflow/envs/base.yaml
+++ b/workflow/envs/base.yaml
@@ -1,6 +1,6 @@
 channels:
   - conda-forge
-  - defaults
+  - nodefaults
 dependencies:
   - curl ==7.87.0
   - wget ==1.21.4

--- a/workflow/envs/checksum.yaml
+++ b/workflow/envs/checksum.yaml
@@ -1,5 +1,5 @@
 channels:
   - conda-forge
-  - defaults
+  - nodefaults
 dependencies:
   - sha256 ==1.0

--- a/workflow/envs/datastuff.yaml
+++ b/workflow/envs/datastuff.yaml
@@ -1,6 +1,6 @@
 channels:
   - conda-forge
-  - defaults
+  - nodefaults
 dependencies:
   - python =3.12
   - polars =0.20

--- a/workflow/envs/efetch.yaml
+++ b/workflow/envs/efetch.yaml
@@ -1,7 +1,7 @@
 channels:
   - conda-forge
   - bioconda
-  - defaults
+  - nodefaults
 dependencies:
   - python =3.10
   - requests ==2.32.3

--- a/workflow/envs/jq.yaml
+++ b/workflow/envs/jq.yaml
@@ -1,6 +1,6 @@
 channels:
   - conda-forge
-  - defaults
+  - nodefaults
 dependencies:
   - jq ==1.7.1
   - pigz ==2.8

--- a/workflow/envs/mehari.yaml
+++ b/workflow/envs/mehari.yaml
@@ -1,5 +1,6 @@
 channels:
   - conda-forge
   - bioconda
+  - nodefaults
 dependencies:
   - mehari ==0.26.1

--- a/workflow/envs/samtools.yaml
+++ b/workflow/envs/samtools.yaml
@@ -1,6 +1,6 @@
 channels:
   - conda-forge
   - bioconda
-  - defaults
+  - nodefaults
 dependencies:
   - samtools ==1.19

--- a/workflow/envs/seqrepo.yaml
+++ b/workflow/envs/seqrepo.yaml
@@ -1,7 +1,7 @@
 channels:
   - conda-forge
   - bioconda
-  - defaults
+  - nodefaults
 dependencies:
  - python =3.10
  - entrez-direct =16.2


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new channel configuration (`nodefaults`) across various environment files to enhance package management by excluding default channels.
	- Updated dependencies in the `datastuff.yaml` file to include specific versions of Python, Polars, and Pandas, improving compatibility and performance.

- **Bug Fixes**
	- Adjusted formatting in `checksum.yaml` to ensure proper file structure.

- **Chores**
	- Commented out unnecessary dependencies in `datastuff.yaml` to streamline the environment setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->