### PR TITLE
fix: update hgnc download url

### DIFF
--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -50,7 +50,7 @@ def get_hgnc_complete_set_download_url(_wildcards: Wildcards) -> str:
         where = "quarterly"
     else:
         where = "monthly"
-    url = f"http://ftp.ebi.ac.uk/pub/databases/genenames/hgnc/archive/{where}/json/hgnc_complete_set_{version}.json"
+    url = f"storage.googleapis.com/public-download-files/hgnc/archive/archive/{where}/json/hgnc_complete_set_{version}.json"
     return url
 
 


### PR DESCRIPTION
has changed from ensembl ftp to google storage, see https://www.genenames.org/download/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the source URL for downloading the HGNC complete set JSON file to a new Google Cloud Storage location. 

- **Bug Fixes**
	- No bug fixes were made in this release. 

- **Documentation**
	- No documentation updates were included in this release. 

- **Refactor**
	- No refactoring changes were introduced. 

- **Style**
	- No style changes were made. 

- **Tests**
	- No new tests were added. 

- **Chores**
	- No additional chores were performed. 

- **Revert**
	- No reverts were included.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->