### PR TITLE
fix: bump cdot to 0.2.27, snakemake wrappers

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@ This repository contains a snakemake workflow to build mehari transcript databas
 
 Databases are built for each combination of genome release (GRCh37, GRCh38) and reference source (ensembl, refseq):
 
-- mehari-data `v0.7.0`
+- mehari-data `v0.9.0`
   - uses:
-    - mehari `v0.26.1`
-    - cdot: `v0.2.26`
+    - mehari `v0.30.1`
+    - cdot: `v0.2.27`
   - `GRCh37-refseq`
       - genome release: GRCh37.p13
       - VEP/ENSEMBL equivalent: `105`

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -27,7 +27,7 @@ reference:
 sources:
   GRCh38-refseq:
     cdot:
-      release: 0.2.26
+      release: 0.2.27
       custom: GCF_000001405.40_GRCh38.p14_genomic.110.gff
     known_issues:
       - id_type: gene_symbol
@@ -110,7 +110,7 @@ sources:
 
   GRCh37-refseq:
     cdot:
-      release: 0.2.26
+      release: 0.2.27
       custom: GCF_000001405.25_GRCh37.p13_genomic.105.20201022.gff
     known_issues:
       - id_type: gene_symbol
@@ -151,8 +151,8 @@ sources:
   # (rules::cdot::cdot_chrMT expects 'GRCh38-ensembl' to be defined)
   GRCh38-ensembl:
     cdot:
-      release: 0.2.26
-      custom: ensembl.Homo_sapiens.GRCh38.112.gff3
+      release: 0.2.27
+      custom: ensembl.Homo_sapiens.GRCh38.112.gtf
     known_issues:
       - id_type: hgnc_id
         id: "HGNC:32925"
@@ -213,8 +213,8 @@ sources:
         description: novel gene/transcript without HGNC id
   GRCh37-ensembl:
     cdot:
-      release: 0.2.26
-      custom: ensembl.Homo_sapiens.GRCh37.87.gff3
+      release: 0.2.27
+      custom: ensembl.Homo_sapiens.GRCh37.87.gtf
     known_issues:
       - id_type: gene_symbol
         id: "ATXN8"

--- a/workflow/rules/download.smk
+++ b/workflow/rules/download.smk
@@ -10,7 +10,7 @@ rule get_ensembl_sequence:
         "logs/{assembly}-ensembl/get_ensembl_sequence.{datatype}.log",
     cache: "omit-software"  # save space and time with between workflow caching (see docs)
     wrapper:
-        "v3.11.0/bio/reference/ensembl-sequence"
+        "v5.0.2/bio/reference/ensembl-sequence"
 
 
 rule merge_ensembl_sequence:

--- a/workflow/rules/validate.smk
+++ b/workflow/rules/validate.smk
@@ -79,4 +79,4 @@ rule datavzrd:
     log:
         "logs/datavzrd_report/{assembly}-{source}/seqrepo/check_mehari_db.log",
     wrapper:
-        "v3.13.1/utils/datavzrd"
+        "v5.0.2/utils/datavzrd"


### PR DESCRIPTION
Release-As: 0.9.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated `mehari-data` version to `v0.9.0`.
	- Added new rules for handling RefSeq data in the workflow.
  
- **Bug Fixes**
	- Improved Ensembl sequence retrieval with an upgraded wrapper version.

- **Documentation**
	- Updated README to reflect new versions of dependencies and transcript database filenames.

- **Chores**
	- Cleaned up configuration files by removing commented-out lines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->