### PR TITLE
fix: simplify clinvar information extraction, bump mehari version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ defaults:
     shell: bash -el {0}
 
 env:
-  MEHARI_VERSION: "0.41.2"
+  MEHARI_VERSION: "0.42.0"
   SNAKEMAKE_OUTPUT_CACHE: "${{ github.workspace }}/snakemake_cache"
 
 jobs:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ defaults:
     shell: bash -el {0}
 
 env:
-  MEHARI_VERSION: "0.30.0"
+  MEHARI_VERSION: "0.41.2"
   SNAKEMAKE_OUTPUT_CACHE: "${{ github.workspace }}/snakemake_cache"
 
 jobs:

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -51,60 +51,60 @@ sources:
     fixes:
       # for the following set of transcripts, check against nuccore whether the CDS region is correct
       fix_cds: [
-        # SHANK3
-        "NM_001372044.2",
-        # CAPN8
-        "NM_001143962.2",
-        # CASP8AP2
-        "NM_001137667.2",  # partial, MANE Select
-        # "NM_001137668.2",  # partial
-        # "NM_012115.4",     # partial
-        # DAG1
-        "NM_001177639.3",    # The RefSeq transcript has 1 non-frameshifting indel compared to this genomic sequence
-        # FOXO6
-        # "NM_001291281.3",  # partial, MANE Select
-        # POLK
-        # "NM_001345921.3",  # partial
-        # "NM_001345922.3",  # partial
-        # "NM_001372044.2",  # partial, RefSeq Select
-        # "NM_001387110.3",  # partial
-        # "NM_001387111.3",  # partial
-        # "NM_001395899.1",  # partial
-        # "NM_001395901.1",  # partial
-        # "NM_001395902.1",  # partial
-        # "NM_016218.6",     # partial, RefSeq Select
-        # SAMD1
-        # "NM_138352.3",     # partial, MANE Select
-        # MUC19
-        # "NM_173600.2",     # partial, RefSeq Select
-        # older versions in cdot than available in the current cdna ref releases:
-        # "NM_001401501.1",  # partial
-        # "NM_002457.4",     # partial, RefSeq Select
-        # "NM_003890.2",     # partial, RefSeq Select
-        # "NM_012234.6",     # partial, RefSeq Select
-        # "NM_017940.6",
+#        # SHANK3
+#        "NM_001372044.2",
+#        # CAPN8
+#        "NM_001143962.2",
+#        # CASP8AP2
+#        "NM_001137667.2",  # partial, MANE Select
+#        # "NM_001137668.2",  # partial
+#        # "NM_012115.4",     # partial
+#        # DAG1
+#        "NM_001177639.3",    # The RefSeq transcript has 1 non-frameshifting indel compared to this genomic sequence
+#        # FOXO6
+#        # "NM_001291281.3",  # partial, MANE Select
+#        # POLK
+#        # "NM_001345921.3",  # partial
+#        # "NM_001345922.3",  # partial
+#        # "NM_001372044.2",  # partial, RefSeq Select
+#        # "NM_001387110.3",  # partial
+#        # "NM_001387111.3",  # partial
+#        # "NM_001395899.1",  # partial
+#        # "NM_001395901.1",  # partial
+#        # "NM_001395902.1",  # partial
+#        # "NM_016218.6",     # partial, RefSeq Select
+#        # SAMD1
+#        # "NM_138352.3",     # partial, MANE Select
+#        # MUC19
+#        # "NM_173600.2",     # partial, RefSeq Select
+#        # older versions in cdot than available in the current cdna ref releases:
+#        # "NM_001401501.1",  # partial
+#        # "NM_002457.4",     # partial, RefSeq Select
+#        # "NM_003890.2",     # partial, RefSeq Select
+#        # "NM_012234.6",     # partial, RefSeq Select
+#        # "NM_017940.6",
       ]
       # for the following refseq transcripts, lookup the ensembl matches and include the respective
       # sequences in seqrepo and the transcript information from cdot
       add_from_ensembl: [
-        # Invalid CDS length in cdot:
-        # Most (or all?) of these are marked as CDS join(a..b,c..d) in nuccore
-        "NM_001172437.2",
-        "NM_001184961.1",
-        "NM_015068.3",
-        "NM_182705.2",
-        "NM_001145051.2",
-        "NM_001301020.1",
-        "NM_004152.3",
-        "NM_001301302.1",
-        "NM_002537.3",
-        "NM_001134939.1",
-        "NM_001301371.1",
-        "NM_016178.2",
-        "NM_053005.5",
-        # MANE select but refseq transcript + annotation seems to be problematic (missing stop codon)
-        "NM_001405666.3",
-        "NM_012234.6",
+#        # Invalid CDS length in cdot:
+#        # Most (or all?) of these are marked as CDS join(a..b,c..d) in nuccore
+#        "NM_001172437.2",
+#        "NM_001184961.1",
+#        "NM_015068.3",
+#        "NM_182705.2",
+#        "NM_001145051.2",
+#        "NM_001301020.1",
+#        "NM_004152.3",
+#        "NM_001301302.1",
+#        "NM_002537.3",
+#        "NM_001134939.1",
+#        "NM_001301371.1",
+#        "NM_016178.2",
+#        "NM_053005.5",
+#        # MANE select but refseq transcript + annotation seems to be problematic (missing stop codon)
+#        "NM_001405666.3",
+#        "NM_012234.6",
       ]
 #      swap_version:
 #        - { "from": "NM_012234.6", "to": "NM_012234.7"}
@@ -133,24 +133,24 @@ sources:
         description: "Fragile site. No Transcript. No Protein."
     fixes:
       fix_cds: [
-        # SHANK3
-        "NM_001372044.2",
-        # CAPN8
-        "NM_001143962.2",
-        # SECC22B
-        "NM_004892.6",
+#        # SHANK3
+#        "NM_001372044.2",
+#        # CAPN8
+#        "NM_001143962.2",
+#        # SECC22B
+#        "NM_004892.6",
       ]
       add_from_ensembl: [
-        # All of these are marked as CDS join(a..b,c..d) in nuccore:
-        # OAZ1
-        "NM_004152.3",
-        "NM_001301020.1",
-        # OAZ2
-        "NM_002537.3",
-        "NM_001301302.1",
-        # OAZ3
-        "NM_001301371.1",
-        "NM_001134939.1",
+#        # All of these are marked as CDS join(a..b,c..d) in nuccore:
+#        # OAZ1
+#        "NM_004152.3",
+#        "NM_001301020.1",
+#        # OAZ2
+#        "NM_002537.3",
+#        "NM_001301302.1",
+#        # OAZ3
+#        "NM_001301371.1",
+#        "NM_001134939.1",
       ]
 
   # the following entry is semi hardcoded for now

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -283,5 +283,5 @@ clinvar-data-jsonl:
 
 # mehari version to use (currently ignored)
 mehari:
-  version: 0.39.0
-  docker: "docker://ghcr.io/varfish-org/mehari:0.39.0"
+  version: 0.41.2
+  docker: "docker://ghcr.io/varfish-org/mehari:0.41.2"

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -283,5 +283,5 @@ clinvar-data-jsonl:
 
 # mehari version to use (currently ignored)
 mehari:
-  version: 0.41.2
-  docker: "docker://ghcr.io/varfish-org/mehari:0.41.2"
+  version: 0.42.0
+  docker: "docker://ghcr.io/varfish-org/mehari:0.42.0"

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -275,11 +275,11 @@ human-phenotype-ontology:
     # check https://github.com/obophenotype/human-phenotype-ontology/releases/ for available versions
     # note that sometimes the release tag starts with "v", sometimes it does not
     # and sometimes the release date in the title does not match the release date in the filenames
-    release: "v2025-11-24"
+    release: "v2026-02-16"
 
 clinvar-data-jsonl:
   # check https://github.com/varfish-org/clinvar-data-jsonl/releases/ for available versions.
-  release: "20260104+0.18.5"
+  release: "20260226+0.18.5"
 
 # mehari version to use (currently ignored)
 mehari:

--- a/environment.yaml
+++ b/environment.yaml
@@ -2,4 +2,4 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - snakemake =8.25.3
+  - snakemake =9.19.0

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -1,6 +1,6 @@
 from snakemake.utils import validate, min_version
 
-min_version("8.25.3")
+min_version("9.19.0")
 
 
 configfile: "config/config.yaml"

--- a/workflow/envs/mehari.yaml
+++ b/workflow/envs/mehari.yaml
@@ -3,4 +3,4 @@ channels:
   - bioconda
   - nodefaults
 dependencies:
-  - mehari ==0.39.0
+  - mehari ==0.41.2

--- a/workflow/envs/mehari.yaml
+++ b/workflow/envs/mehari.yaml
@@ -3,4 +3,4 @@ channels:
   - bioconda
   - nodefaults
 dependencies:
-  - mehari ==0.41.2
+  - mehari ==0.42.0

--- a/workflow/envs/seqrepo.yaml
+++ b/workflow/envs/seqrepo.yaml
@@ -9,5 +9,8 @@ dependencies:
  - ratelimit =2.2.1
  - requests =2.32.3
  - bioutils =0.6.1
- - biocommons.seqrepo =0.6.11
- - setuptools =82.0.1
+# - biocommons.seqrepo =0.6.11
+# - setuptools =82.0.1
+ - pip
+ - pip:
+   - biocommons.seqrepo @ git+https://github.com/biocommons/biocommons.seqrepo.git@72c9091c83e689e7880bc1f0df34326a61dfef18

--- a/workflow/envs/seqrepo.yaml
+++ b/workflow/envs/seqrepo.yaml
@@ -10,3 +10,4 @@ dependencies:
  - requests =2.32.3
  - bioutils =0.6.1
  - biocommons.seqrepo =0.6.11
+ - setuptools =82.0.1

--- a/workflow/envs/seqrepo.yaml
+++ b/workflow/envs/seqrepo.yaml
@@ -3,12 +3,10 @@ channels:
   - bioconda
   - nodefaults
 dependencies:
- - python =3.10
+ - python =3.11
  - entrez-direct =16.2
  - htslib =1.17
  - ratelimit =2.2.1
  - requests =2.32.3
- - bioutils =0.5.7
- - pip
- - pip:
-     - git+https://github.com/biocommons/biocommons.seqrepo@c4e620b0ead9270562231144a996ef0b367356f1
+ - bioutils =0.6.1
+ - biocommons.seqrepo =0.6.11

--- a/workflow/profiles/default/config.v8+.yaml
+++ b/workflow/profiles/default/config.v8+.yaml
@@ -5,3 +5,4 @@ cache: True
 apptainer-args: "-B ${SNAKEMAKE_OUTPUT_CACHE}:${SNAKEMAKE_OUTPUT_CACHE}:rw"
 resources:
   ratelimit: 3
+retries: 5

--- a/workflow/rules/cdot.smk
+++ b/workflow/rules/cdot.smk
@@ -120,6 +120,8 @@ rule lookup_ensembl_ids_for_refseq_ids:
         accessions="results/{assembly}-{source}/cdot/{assembly}-{source}.partial_but_select.txt",
     params:
         additional_accessions=transcripts_to_lookup_ensembl_ids_for,
+    resources:
+        runtime=lambda wildcards, attempt: 10 ** (attempt - 1) + 60,
     output:
         tsv="results/{assembly}-{source}/lookup/refseq_id_to_ensembl_id.tsv",
     log:

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -1,6 +1,6 @@
 from typing import Callable
 
-from snakemake.io import InputFiles, Wildcards
+from snakemake.iocontainers import InputFiles, Wildcards
 
 
 def get_alias(wildcards: Wildcards) -> str:

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -116,7 +116,7 @@ def get_mehari_cdot_param_string(wildcards: Wildcards, input: InputFiles) -> str
     expected_input_keys = input.keys()
     for key in cdot_files.keys():
         assert key in expected_input_keys
-    return " ".join(f"--path-cdot-json {path}" for path in cdot_files.values())
+    return " ".join(f"--annotation {path}" for path in cdot_files.values())
 
 
 def get_mehari_check_cdot_param_string(wildcards: Wildcards, input: InputFiles) -> str:

--- a/workflow/rules/mehari.smk
+++ b/workflow/rules/mehari.smk
@@ -24,8 +24,8 @@ rule mehari_build_txs_db:
         "logs/{assembly}-{source}/mehari/seqrepo/build_txs_db.log",
     benchmark:
         "benchmarks/{assembly}-{source}/mehari/seqrepo/build_txs_db.tsv"
-    # container:
-    #     get_mehari_docker_url()
+    container:
+        get_mehari_docker_url()
     shell:
         """
         mehari db create \
@@ -62,8 +62,8 @@ rule mehari_merge_txs_dbs_per_assembly:
         dbs_param=lambda wildcards, input: " ".join(
             f"--database {db}" for db in input.dbs
         ),
-    # container:
-    #     get_mehari_docker_url()
+    container:
+        get_mehari_docker_url()
     shell:
         """
         (mehari db merge \

--- a/workflow/rules/mehari.smk
+++ b/workflow/rules/mehari.smk
@@ -10,7 +10,7 @@ rule mehari_build_txs_db:
     threads: workflow.cores / 2
     params:
         mane=lambda wildcards, input: (
-            f"--path-mane-txs-tsv {input.tags}"
+            f"--mane-transcripts {input.tags}"
             if wildcards.assembly == "GRCh37"
             else ""
         ),
@@ -24,15 +24,15 @@ rule mehari_build_txs_db:
         "logs/{assembly}-{source}/mehari/seqrepo/build_txs_db.log",
     benchmark:
         "benchmarks/{assembly}-{source}/mehari/seqrepo/build_txs_db.tsv"
-    container:
-        get_mehari_docker_url()
+    # container:
+    #     get_mehari_docker_url()
     shell:
         """
         mehari db create \
-        --path-out {output.txs} \
-        --path-seqrepo-instance {input.seqrepo_instance} \
+        --output {output.txs} \
+        --seqrepo {input.seqrepo_instance} \
         {params.cdot} \
-        --cdot-version {params.cdot_version} \
+        --annotation-version {params.cdot_version} \
         --assembly {params.assembly} \
         {params.assembly_version} \
         --transcript-source {params.transcript_source} \
@@ -62,8 +62,8 @@ rule mehari_merge_txs_dbs_per_assembly:
         dbs_param=lambda wildcards, input: " ".join(
             f"--database {db}" for db in input.dbs
         ),
-    container:
-        get_mehari_docker_url()
+    # container:
+    #     get_mehari_docker_url()
     shell:
         """
         (mehari db merge \

--- a/workflow/rules/validate.smk
+++ b/workflow/rules/validate.smk
@@ -20,7 +20,7 @@ rule check_mehari_db:
         tx_db_report_sha256="results/{assembly}-{source}/mehari/seqrepo/txs.bin.zst.report.jsonl.sha256",
         hgnc="results/hgnc/hgnc_complete_set.json",
         genes_to_disease="results/human-phenotype-ontology/genes_to_disease_with_hgnc_id.tsv",
-        clinvar_tx_acc_counts=rules.clinvar_tx_accs.output.tx_acc_count,
+        clinvar_tx_acc_counts=rules.clinvar_tx_acc_counts.output.tx_acc_count,
         clinvar_hgnc_counts=rules.clinvar_hgnc_id_counts.output.hgnc_id_counts,
         known_issues="results/{assembly}-{source}/fixes/known_issues.tsv",
     output:

--- a/workflow/rules/validate.smk
+++ b/workflow/rules/validate.smk
@@ -33,8 +33,8 @@ rule check_mehari_db:
         cdot=get_mehari_check_cdot_param_string,
     log:
         "logs/{assembly}-{source}/mehari/seqrepo/check.log",
-    # container:
-    #     get_mehari_docker_url()
+    container:
+        get_mehari_docker_url()
     shell:
         """(
         mehari db check \

--- a/workflow/rules/validate.smk
+++ b/workflow/rules/validate.smk
@@ -33,8 +33,8 @@ rule check_mehari_db:
         cdot=get_mehari_check_cdot_param_string,
     log:
         "logs/{assembly}-{source}/mehari/seqrepo/check.log",
-    container:
-        get_mehari_docker_url()
+    # container:
+    #     get_mehari_docker_url()
     shell:
         """(
         mehari db check \

--- a/workflow/scripts/cdot/extract_chrmt.py
+++ b/workflow/scripts/cdot/extract_chrmt.py
@@ -9,7 +9,7 @@ import gzip
 import json
 import sys
 from contextlib import redirect_stderr
-from snakemake.script import snakemake
+
 
 #: Contig name for chrMT
 CHRMT_CONTIG = "NC_012920.1"

--- a/workflow/scripts/cdot/extract_tags.py
+++ b/workflow/scripts/cdot/extract_tags.py
@@ -11,7 +11,7 @@ import json
 import sys
 import typing
 from contextlib import redirect_stderr
-from snakemake.script import snakemake
+
 
 
 def main(paths: typing.Iterable[str], file=sys.stdout):

--- a/workflow/scripts/cdot/fetch_incorrect_entries.py
+++ b/workflow/scripts/cdot/fetch_incorrect_entries.py
@@ -1,5 +1,5 @@
 from contextlib import redirect_stderr
-from snakemake.script import snakemake
+
 
 import requests
 import gzip

--- a/workflow/scripts/cdot/fix_incorrect_cds.py
+++ b/workflow/scripts/cdot/fix_incorrect_cds.py
@@ -9,7 +9,7 @@ from typing import Any
 from xml.etree.ElementTree import ElementTree
 
 import pandas as pd
-from snakemake.script import snakemake
+
 
 Exon = namedtuple(
     "Exon",

--- a/workflow/scripts/cdot/graft_ensembl_ids.py
+++ b/workflow/scripts/cdot/graft_ensembl_ids.py
@@ -10,7 +10,7 @@ import sys
 
 import pandas as pd
 from contextlib import redirect_stderr
-from snakemake.script import snakemake
+
 
 REFSEQ_KEY = "RefSeq mRNA ID"
 ENSEMBL_GENE_KEY = "Gene stable ID version"

--- a/workflow/scripts/download_refseq.py
+++ b/workflow/scripts/download_refseq.py
@@ -1,5 +1,8 @@
 from contextlib import redirect_stderr
-from snakemake.script import snakemake
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from snakemake.iocontainers import snakemake
 
 from snakemake import shell
 

--- a/workflow/scripts/fetch_missing_sequences.py
+++ b/workflow/scripts/fetch_missing_sequences.py
@@ -7,12 +7,14 @@ from io import BytesIO
 from itertools import islice
 from math import ceil
 from time import sleep
-from typing import Collection
+from typing import Collection, TYPE_CHECKING
 
 import requests
 from dinopy import FastaReader, FastaWriter
-from snakemake.script import snakemake
 from snakemake import shell
+
+if TYPE_CHECKING:
+    from snakemake.iocontainers import snakemake
 
 
 def batched(iterable, n):

--- a/workflow/scripts/human_phenotype_ontology/add_hgnc_id_to_genes_to_disease.py
+++ b/workflow/scripts/human_phenotype_ontology/add_hgnc_id_to_genes_to_disease.py
@@ -1,7 +1,7 @@
 import json
 import sys
 from contextlib import redirect_stderr
-from snakemake.script import snakemake
+
 
 import pandas as pd
 

--- a/workflow/scripts/known_issues.py
+++ b/workflow/scripts/known_issues.py
@@ -1,7 +1,7 @@
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from snakemake.script import snakemake
+    from snakemake.iocontainers import snakemake
 
 from contextlib import redirect_stderr
 

--- a/workflow/scripts/lookup_ensembl_ids_for_refseq_ids.py
+++ b/workflow/scripts/lookup_ensembl_ids_for_refseq_ids.py
@@ -1,9 +1,12 @@
 from contextlib import redirect_stderr
 from io import StringIO
+from typing import TYPE_CHECKING
 
 import pandas as pd
 import requests
-from snakemake.script import snakemake
+
+if TYPE_CHECKING:
+    from snakemake.iocontainers import snakemake
 
 HEADER = {
     "refseq_mrna": "RefSeq mRNA ID",

--- a/workflow/scripts/lookup_ensembl_ids_for_refseq_ids.py
+++ b/workflow/scripts/lookup_ensembl_ids_for_refseq_ids.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING
 
 import pandas as pd
 import requests
+import time
 
 if TYPE_CHECKING:
     from snakemake.iocontainers import snakemake
@@ -66,6 +67,8 @@ def main(refseq_ids: set[str]):
 
 
 with open(snakemake.log[0], "w") as log, redirect_stderr(log):
+    sleep_s = snakemake.resources.runtime
+    time.sleep(sleep_s)
     refseq_ids = set(snakemake.params.additional_accessions)
     with open(snakemake.input.accessions, "rt") as f:
         for line in f:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactoring**
  * ClinVar outputs streamlined to produce standardized tab-delimited transcript-accession and HGNC ID count summary files (renamed for clarity).

* **Chores**
  * Disabled selected transcript CDS / Ensembl additions from active processing.
  * Updated tool/data and environment versions (Mehari, HPO, ClinVar, Snakemake, Conda).
  * Disabled container execution for some workflow steps and updated scripts for cleaner type-checked imports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->